### PR TITLE
Fix docblock formatting typo in config/ciphersweet.php

### DIFF
--- a/config/ciphersweet.php
+++ b/config/ciphersweet.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    /*
+    /**
      * This controls which cryptographic backend will be used by CipherSweet.
      * Unless you have specific compliance requirements, you should choose
      * "nacl".
@@ -10,7 +10,7 @@ return [
      */
     'backend' => env('CIPHERSWEET_BACKEND', 'nacl'),
 
-    /*
+    /**
      * Select which key provider your application will use. The default option
      * is to read a string literal out of .env, but it's also possible to
      * provide the key in a file or use random keys for testing.
@@ -19,7 +19,7 @@ return [
      */
     'provider' => env('CIPHERSWEET_PROVIDER', 'string'),
 
-    /*
+    /**
      * Set provider-specific options here. "string" will read the key directly
      * from your .env file. "file" will read the contents of the specified file
      * to use as your key. "custom" points to a factory class that returns a


### PR DESCRIPTION
The config file uses docblock comments to document each array key. The `/*` works for inline comments but needs `/**` to allow for multi-line docblock syntax highlighting in IDE editors. This was likely not caught in tests because it is a valid comment for the PHP interpreter.

#### Before

<img width="709" alt="BeforeFix" src="https://user-images.githubusercontent.com/2792208/178147029-b4e9226f-8160-4885-b2f6-af2dfc638c5c.png">

#### After

<img width="704" alt="AfterFix" src="https://user-images.githubusercontent.com/2792208/178147037-ee351cd7-6ffc-4e4e-ae1d-0f401942dccd.png">

