### PR TITLE
Fix Service Provider `buildBackend` method to use correct config array key

### DIFF
--- a/src/LaravelCipherSweetServiceProvider.php
+++ b/src/LaravelCipherSweetServiceProvider.php
@@ -38,7 +38,7 @@ class LaravelCipherSweetServiceProvider extends PackageServiceProvider
 
     protected function buildBackend(): BackendInterface
     {
-        return match (config('ciphersweet.encryption.backend')) {
+        return match (config('ciphersweet.backend')) {
             'fips' => new FIPSCrypto(),
             'boring' => new BoringCrypto(),
             default => new ModernCrypto(),


### PR DESCRIPTION
The `LaravelCipherSweetServiceProvider` [buildBackend()](https://github.com/spatie/laravel-ciphersweet/blob/main/src/LaravelCipherSweetServiceProvider.php#L41) method uses the `config('ciphersweet.encryption.backend')` which expects a value at `['encryption']['backend']` in [config/ciphersweet.php](https://github.com/spatie/laravel-ciphersweet/blob/main/config/ciphersweet.php#L11). 

The config file currently has `[backend]` which corresponds with the `CIPHERSWEET_BACKEND` .env variable.

```php
return [
    'backend' => env('CIPHERSWEET_BACKEND', 'nacl'),
    //
];
```

This PR changes the Service Provider to use the correct configuration path. 

Alternatively, this PR could be changed to update the config file to add a nested `encryption` array, however this would create an inconsistency with the `CIPHERSWEET_BACKEND` .env variable unless it was renamed to `CIPHERSWEET_ENCRYPTION_BACKEND` which would likely be considered a breaking change.

```php
return [
    'encryption' => [
         'backend' => env('CIPHERSWEET_BACKEND', 'nacl'),
    ],
    //
];
```

### Impact and Workaround

Until this PR is merged, the current README documentation for setting `CIPHERSWEET_BACKEND` does not have any effect so you cannot set `boring` or `fips` values. 

You can publish the config file with `php artisan vendor:publish --tag="ciphersweet-config"` and customize the array as shown above with adding an `encryption` key with the `backend` key in a child array.