### PR TITLE
Add docblock to configureCipherSweet in README with usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,43 @@ class User extends Model implements CipherSweetEncrypted
 {
     use UsesCipherSweet;
     
+    /**
+     * Encrypted Fields
+     *
+     * Each column that should be encrypted should be added below. Each column
+     * in the migration should be a `text` type to store the encrypted value.
+     *
+     * ```
+     * ->addField('column_name')
+     * ->addBooleanField('column_name')
+     * ->addIntegerField('column_name')
+     * ->addTextField('column_name')
+     * ```
+     *
+     * A JSON array can be encrypted as long as the key structure is defined in
+     * a field map. See the docs for details on defining field maps.
+     *
+     * ```
+     * ->addJsonField('column_name', $fieldMap)
+     * ```
+     *
+     * Each field that should be searchable using an exact match needs to be
+     * added as a blind index. Partial search is not supported. See the docs
+     * for details on bit sizes and how to use compound indexes.
+     *
+     * ```
+     * ->addBlindIndex('column_name', new BlindIndex('column_name_index'))
+     * ```
+     *
+     * @see https://github.com/spatie/laravel-ciphersweet
+     * @see https://ciphersweet.paragonie.com/
+     * @see https://ciphersweet.paragonie.com/php/blind-index-planning
+     * @see https://github.com/paragonie/ciphersweet/blob/master/src/EncryptedRow.php
+     *
+     * @param EncryptedRow $encryptedRow
+     *
+     * @return void
+     */
     public static function configureCipherSweet(EncryptedRow $encryptedRow): void
     {
         $encryptedRow


### PR DESCRIPTION
It took approximately 2 hours to parse the CipherSweet documentation about how to add encrypted fields. To improve the developer experience and allow easy getting started adoption, this PR adds a docblock to the `configureCipherSweet` method shown in the `README` that developers will copy into each Laravel model.

The example usage provided in the docblock should cover 80-90% of common use cases and allow package adoption in less than 15 minutes.