### PR TITLE
Implement custom backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,74 @@ php artisan ciphersweet:encrypt "App\User" <your-new-key>
 
 This will update all the encrypted fields and blind indexes of the model. Once this is done, you can update your environment or config file to use the new key.
 
+## Implementing a custom backend
+
+You can implement a custom backend by setting the `ciphersweet.backend` config value to `custom`.
+
+The `ciphersweet.backend.custom` config value must then be set to an invokeable factory class that returns an implementation of `ParagonIE\CipherSweet\Contract\BackendInterface`
+
+```php
+class CustomBackendFactory {
+    public function __invoke()
+    {
+        return new CustomBackend();
+    }
+}
+
+class CustomBackend implements BackendInterface {
+
+    public function encrypt(string $plaintext, SymmetricKey $key, string $aad = ''): string
+    {
+        // Your logic here.
+    }
+
+    public function decrypt(string $ciphertext, SymmetricKey $key, string $aad = ''): string
+    {
+        // Your logic here.
+    }
+
+    public function blindIndexFast(string $plaintext, SymmetricKey $key, ?int $bitLength = null): string
+    {
+        // Your logic here.
+    }
+
+    public function blindIndexSlow(string $plaintext, SymmetricKey $key, ?int $bitLength = null, array $config = []): string
+    {
+        // Your logic here.
+    }
+
+    public function getIndexTypeColumn(string $tableName, string $fieldName, string $indexName): string
+    {
+        // Your logic here.
+    }
+
+    public function deriveKeyFromPassword(string $password, string $salt): SymmetricKey
+    {
+        // Your logic here.return new SymmetricKey('123');
+    }
+
+    public function doStreamDecrypt($inputFP, $outputFP, SymmetricKey $key, int $chunkSize = 8192): bool
+    {
+        // Your logic here.
+    }
+
+    public function doStreamEncrypt($inputFP, $outputFP, SymmetricKey $key, int $chunkSize = 8192, string $salt = Constants::DUMMY_SALT): bool
+    {
+        // Your logic here.
+    }
+
+    public function getFileEncryptionSaltOffset(): int
+    {
+        // Your logic here.
+    }
+
+    public function getPrefix(): string
+    {
+        // Your logic here.
+    }
+}
+```
+
 ## Implementing a custom key provider
 
 You can implement a custom key provider by setting the `ciphersweet.provider` config value to `custom`.

--- a/config/ciphersweet.php
+++ b/config/ciphersweet.php
@@ -6,9 +6,17 @@ return [
      * Unless you have specific compliance requirements, you should choose
      * "nacl".
      *
-     * Supported: "boring", "fips", "nacl"
+     * Supported: "boring", "fips", "nacl", "custom"
      */
     'backend' => env('CIPHERSWEET_BACKEND', 'nacl'),
+
+    /**
+     * Set backend-specific options here. "custom" points to a factory class that returns a
+     * backend from its `__invoke` method. Please see the docs for more details.
+     */
+    'backends' => [
+        // 'custom' => CustomBackendFactory::class,
+    ],
 
     /**
      * Select which key provider your application will use. The default option

--- a/src/LaravelCipherSweetServiceProvider.php
+++ b/src/LaravelCipherSweetServiceProvider.php
@@ -38,6 +38,17 @@ class LaravelCipherSweetServiceProvider extends PackageServiceProvider
 
     protected function buildBackend(): BackendInterface
     {
+        if (config('ciphersweet.backend') === 'custom') {
+            $class = config('ciphersweet.backends.custom');
+            $backend = (new $class())();
+
+            if (! $backend instanceof BackendInterface) {
+                throw new \Exception($backend::class . ' must implement ' . BackendInterface::class);
+            }
+
+            return $backend;
+        }
+
         return match (config('ciphersweet.backend')) {
             'fips' => new FIPSCrypto(),
             'boring' => new BoringCrypto(),

--- a/tests/CustomBackendTest.php
+++ b/tests/CustomBackendTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use ParagonIE\CipherSweet\Backend\Key\SymmetricKey;
+use ParagonIE\CipherSweet\CipherSweet;
+use ParagonIE\CipherSweet\Contract\BackendInterface;
+use Spatie\LaravelCipherSweet\Tests\TestClasses\User;
+
+class CustomBackendFactory
+{
+    public function __invoke()
+    {
+        return new CustomBackend();
+    }
+}
+
+class InvalidBackendFactory
+{
+    public function __invoke()
+    {
+        return new self();
+    }
+}
+
+class CustomBackend implements BackendInterface
+{
+    public function encrypt(
+        string $plaintext,
+        SymmetricKey $key,
+        string $aad = ''
+    ): string {
+        return 'nacl:123';
+    }
+
+    public function decrypt(
+        string $ciphertext,
+        SymmetricKey $key,
+        string $aad = ''
+    ): string
+    {
+        return 'john@example.com';
+    }
+
+    public function blindIndexFast(
+        string $plaintext,
+        SymmetricKey $key,
+        ?int $bitLength = null
+    ): string {
+        return '123';
+    }
+
+    public function blindIndexSlow(
+        string $plaintext,
+        SymmetricKey $key,
+        ?int $bitLength = null,
+        array $config = []
+    ): string {
+        return '123';
+    }
+
+    public function getIndexTypeColumn(
+        string $tableName,
+        string $fieldName,
+        string $indexName
+    ): string {
+        return '123';
+    }
+
+    public function deriveKeyFromPassword(
+        string $password,
+        string $salt
+    ): SymmetricKey {
+        return new SymmetricKey('123');
+    }
+
+    public function doStreamDecrypt(
+        $inputFP,
+        $outputFP,
+        SymmetricKey $key,
+        int $chunkSize = 8192
+    ): bool {
+        return true;
+    }
+
+    public function doStreamEncrypt(
+        $inputFP,
+        $outputFP,
+        SymmetricKey $key,
+        int $chunkSize = 8192,
+        string $salt = Constants::DUMMY_SALT
+    ): bool {
+        return true;
+    }
+
+    public function getFileEncryptionSaltOffset(): int
+    {
+        return 123;
+    }
+
+    public function getPrefix(): string
+    {
+        return '123';
+    }
+}
+
+it('can use a custom backend', function () {
+    config()->set('ciphersweet.backend', 'custom');
+    config()->set('ciphersweet.backends.custom', CustomBackendFactory::class);
+
+    $this->app->forgetInstance(CipherSweet::class);
+
+    $this->user = User::create([
+        'name' => 'John Doe',
+        'password' => bcrypt('password'),
+        'email' => 'john@example.com',
+    ]);
+
+    expect(DB::table('users')->first()->email)->toStartWith('nacl:')
+        ->and($this->user->email)->toEqual('john@example.com');
+});
+
+it('throws when the factory does not return a valid backend', function () {
+    config()->set('ciphersweet.backend', 'custom');
+    config()->set('ciphersweet.backends.custom', InvalidBackendFactory::class);
+
+    $this->app->forgetInstance(CipherSweet::class);
+
+    $this->expectExceptionMessage("InvalidBackendFactory must implement " . BackendInterface::class);
+
+    User::create([
+        'name' => 'John Doe',
+        'password' => bcrypt('password'),
+        'email' => 'john@example.com',
+    ]);
+});


### PR DESCRIPTION
Following up on [a recent discussion](https://github.com/spatie/laravel-ciphersweet/discussions/28#discussioncomment-5479231) and mirroring implementation patterns from [a recent commit](https://github.com/spatie/laravel-ciphersweet/commit/ce9a7e6d6647b015aaee9cf4898b026777a6c90f), this PR aims to allow support for custom backends in the same way that custom key providers are supported.