### PR TITLE
Create a blind index on the first X characters.

### DIFF
--- a/src/Transformers/FirstXCharacters.php
+++ b/src/Transformers/FirstXCharacters.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+namespace Spatie\LaravelCipherSweet\Transformers;
+
+use ParagonIE\CipherSweet\Contract\TransformationInterface;
+use ParagonIE\ConstantTime\Binary;
+
+
+class FirstXCharacters implements TransformationInterface
+{
+
+    public function __construct(private readonly int $characterCount)
+    {}
+
+    /**
+     * Returns the first x characters
+     *
+     * @param string $input
+     * @return string
+     */
+    public function __invoke(
+        #[\SensitiveParameter]
+        mixed $input,
+    ): string {
+        if (Binary::safeStrlen($input) < $this->characterCount) {
+            return $input;
+        }
+
+        return substr($input,0, $this->characterCount);
+    }
+}


### PR DESCRIPTION
Creating a index on the first could of characters. 

Use case:
Search database based on a supplied first part of a Name or email address. For example be able to type in `freek` to search for all email addresses in the database that start with `freek`

Usage:
->addBlindIndex('email', new BlindIndex('email_index_f5', [new FirstXCharacters(5)]));

The f5 in the index is just my naming convention to show that this index is based on the First 5 characters