### PR TITLE
Where starts with

### DIFF
--- a/src/Transformers/FirstXCharacters.php
+++ b/src/Transformers/FirstXCharacters.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+namespace Spatie\LaravelCipherSweet\Transformers;
+
+use ParagonIE\CipherSweet\Contract\TransformationInterface;
+use ParagonIE\ConstantTime\Binary;
+
+
+class FirstXCharacters implements TransformationInterface
+{
+
+    public function __construct(private readonly int $characterCount)
+    {}
+
+    /**
+     * Returns the first x characters
+     *
+     * @param string $input
+     * @return string
+     */
+    public function __invoke(
+        #[\SensitiveParameter]
+        mixed $input,
+    ): string {
+        if (Binary::safeStrlen($input) < $this->characterCount) {
+            return $input;
+        }
+
+        return substr($input,0, $this->characterCount);
+    }
+}


### PR DESCRIPTION
Search the database with blind index and filter results to mimic like
ie: $found = Member::whereStartsWith('email', 'email_index_f4', 'joe@gmail.');

This searches the db for the first 4 characters based on the index, then it filters the results and returns only the records that start with the full search string

Use case:
I want to search my records for the string 'joe@gmail.com'
I have created a blind index of 4 characters (see other pr)

When using the whereStartsWith I specify the index to use , full search string and it returns only where the results start with the full string