### PR TITLE
Fix documentation regarding encryption key setup and use

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,17 @@ An encryption key is used to encrypt your values.  You can generate a new Cipher
 php artisan ciphersweet:generate-key
 ```
 
-### 3. Encrypting model attributes
+### 3. Updating your .env file
+
+After the key has been generated, you should add the generated CipherSweet key to your .env file.
+
+```text
+CIPHERSWEET_KEY=<YOUR-KEY>
+```
+
+The key will be used by your application to manage encrypted values.
+
+### 4. Encrypting model attributes
 
 With this in place, you can run this command to encrypt all values:
 
@@ -174,15 +184,6 @@ The command will update all the encrypted fields and blind indexes of the model.
 
 If you have a lot of rows, this process can take a long time. The command is restartable: it can be re-run without needing to re-encrypt already rotated keys.
 
-### 4. Updating your .env file
-
-After the fields have been encrypted, you should add the generated CipherSweet key to your .env file.
-
-```text
-CIPHERSWEET_KEY=<YOUR-KEY>
-```
-
-The key will be used by your application to read encrypted values.
 
 ### Searching on blind indexes
 

--- a/src/Commands/GenerateKeyCommand.php
+++ b/src/Commands/GenerateKeyCommand.php
@@ -19,10 +19,10 @@ class GenerateKeyCommand extends Command
         $this->info('');
         $this->info($encryptionKey);
         $this->info('');
-        $this->info('First, you should encrypt your model values using this command');
-        $this->info("ciphersweet:encrypt <MODEL-CLASS> {$encryptionKey}");
-        $this->info('');
-        $this->info('Next, you should add this line to your .env file');
+        $this->info('First, you should add this line to your .env file');
         $this->info("CIPHERSWEET_KEY={$encryptionKey}");
+        $this->info('');
+        $this->info('Next, you may encrypt your model values using this command');
+        $this->info("ciphersweet:encrypt <MODEL-CLASS> {$encryptionKey}");
     }
 }


### PR DESCRIPTION
The encryption key needs to be in the .env before related artisan commands can run.  This PR fixes the README.md and the generate-key output info to reflect the steps in the correct order.

Also, changes "...used by your application to read encrypted values" to "...used by your application to manage encrypted values" in README.md.