### PR TITLE
[feat] add permit_empty to config file

### DIFF
--- a/config/ciphersweet.php
+++ b/config/ciphersweet.php
@@ -42,4 +42,12 @@ return [
         ],
         // 'custom' => CustomKeyProviderFactory::class,
     ],
+    /**
+     * The provided code snippet checks whether the $permitEmpty property is set to false
+     * for a given field. If it is not set to false, it throws an EmptyFieldException indicating
+     * that the field is not defined in the row. This ensures that the code enforces the requirement for
+     * the field to have a value and alerts the user if it is empty or undefined.
+     * Supported: "true", "false"
+     */
+    'permit_empty' => false
 ];

--- a/src/Concerns/UsesCipherSweet.php
+++ b/src/Concerns/UsesCipherSweet.php
@@ -72,7 +72,7 @@ trait UsesCipherSweet
 
     public function decryptRow(): void
     {
-        $this->setRawAttributes(static::$cipherSweetEncryptedRow->setPermitEmpty(config('ciphersweet.permit_empty'))->decryptRow($this->getAttributes()), true);
+        $this->setRawAttributes(static::$cipherSweetEncryptedRow->setPermitEmpty(config('ciphersweet.permit_empty', false))->decryptRow($this->getAttributes()), true);
     }
 
     public function scopeWhereBlind(

--- a/src/Concerns/UsesCipherSweet.php
+++ b/src/Concerns/UsesCipherSweet.php
@@ -72,7 +72,7 @@ trait UsesCipherSweet
 
     public function decryptRow(): void
     {
-        $this->setRawAttributes(static::$cipherSweetEncryptedRow->decryptRow($this->getAttributes()), true);
+        $this->setRawAttributes(static::$cipherSweetEncryptedRow->setPermitEmpty(config('ciphersweet.permit_empty'))->decryptRow($this->getAttributes()), true);
     }
 
     public function scopeWhereBlind(


### PR DESCRIPTION
this PR adds permit_empty to the config file. to prevent throwing **EmptyFieldException** if the encrypted row is not selected