### PR TITLE
Ensure null values are not encrypted

### DIFF
--- a/src/Concerns/UsesCipherSweet.php
+++ b/src/Concerns/UsesCipherSweet.php
@@ -40,7 +40,7 @@ trait UsesCipherSweet
         $attributes = $this->getAttributes();
 
         foreach ($fieldsToEncrypt as $field) {
-            $attributes[$field] ??= '';
+            $attributes[$field] ??= NULL;
         }
 
         $this->setRawAttributes(static::$cipherSweetEncryptedRow->encryptRow($attributes));


### PR DESCRIPTION
Currently null values are here converted to empty strings. The empty string is then encrypted, hence null values in the models will also be encrypted.