### PR TITLE
[feat] add table prefix to ciphersweet:encrypt command

### DIFF
--- a/src/Commands/EncryptCommand.php
+++ b/src/Commands/EncryptCommand.php
@@ -14,7 +14,7 @@ use Spatie\LaravelCipherSweet\Contracts\CipherSweetEncrypted;
 
 class EncryptCommand extends Command
 {
-    protected $signature = 'ciphersweet:encrypt {model} {newKey} {sortDirection=asc}';
+    protected $signature = 'ciphersweet:encrypt {model} {newKey} {sortDirection=asc} {tablename?}';
 
     protected $description = 'Encrypt the values of a model';
 
@@ -64,6 +64,7 @@ class EncryptCommand extends Command
 
         $newClass = (new $modelClass());
 
+        $table_name = $this->argument('tablename') ?: $newClass->getTable();
         $this->getOutput()->progressStart(DB::table($newClass->getTable())->count());
         $sortDirection = $this->argument('sortDirection');
 
@@ -73,7 +74,7 @@ class EncryptCommand extends Command
             ->each(function (object $model) use ($modelClass, $newClass, &$updatedRows) {
                 $model = (array)$model;
 
-                $oldRow = new EncryptedRow(app(CipherSweetEngine::class), $newClass->getTable());
+                $oldRow = new EncryptedRow(app(CipherSweetEngine::class), $table_name);
                 $modelClass::configureCipherSweet($oldRow);
 
                 $newRow = new EncryptedRow(


### PR DESCRIPTION
The issue arises when attempting to transfer encrypted data from one table to another. After executing the command on the updated data, the system returns an error with the message **Invalid Ciphertext Header**. This occurs because the code attempts to encrypt the data with the new table name, but encounters a problem in the process.
here is an example:
Imagine you have an "operator_operators" table where email and cellphone information is encrypted. Now, suppose you want to transfer these records to another table named "causers" without utilizing a model. However, attempting to do this with your operator might lead to the following error:

```php
if (!is_string($plaintext)) {
    throw new \SodiumException("Invalid ciphertext");
}
```

This error occurs when the code encounters an unexpected situation during the transfer process, specifically when checking if the plaintext is a string.