### PR TITLE
Addition of `permit_empty` Configuration to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ return [
             'key' => env('CIPHERSWEET_KEY'),
         ],
     ],
+    
+    /*
+     * The provided code snippet checks whether the $permitEmpty property is set to false
+     * for a given field. If it is not set to false, it throws an EmptyFieldException indicating
+     * that the field is not defined in the row. This ensures that the code enforces the requirement for
+     * the field to have a value and alerts the user if it is empty or undefined.
+     * Supported: "true", "false"
+     */
+    'permit_empty' => env('CIPHERSWEET_PERMIT_EMPTY', FALSE)
+
 ];
 ```
 

--- a/config/ciphersweet.php
+++ b/config/ciphersweet.php
@@ -42,12 +42,13 @@ return [
         ],
         // 'custom' => CustomKeyProviderFactory::class,
     ],
-    /**
+
+    /*
      * The provided code snippet checks whether the $permitEmpty property is set to false
      * for a given field. If it is not set to false, it throws an EmptyFieldException indicating
      * that the field is not defined in the row. This ensures that the code enforces the requirement for
      * the field to have a value and alerts the user if it is empty or undefined.
      * Supported: "true", "false"
      */
-    'permit_empty' => false
+    'permit_empty' => env('CIPHERSWEET_PERMIT_EMPTY', FALSE)
 ];


### PR DESCRIPTION
Hi,

This pull request reads the `permit_empty` value from the environment and includes the configuration for this section in the README file.
