### PR TITLE
Catch correct exception when fields are missing during decryption

### DIFF
--- a/src/Observers/ModelObserver.php
+++ b/src/Observers/ModelObserver.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\LaravelCipherSweet\Observers;
 
-use ErrorException;
+use ParagonIE\CipherSweet\Exception\EmptyFieldException;
 use Spatie\LaravelCipherSweet\Contracts\CipherSweetEncrypted;
 
 class ModelObserver
@@ -16,7 +16,7 @@ class ModelObserver
     {
         try {
             $model->decryptRow();
-        } catch (ErrorException) {
+        } catch (EmptyFieldException) {
             // Not all fields are available to decrypt.
         }
     }


### PR DESCRIPTION
Currently the exception thrown during decryption (https://github.com/paragonie/ciphersweet/blob/86d951ef458626b9e1671e66be4f833ec75480fd/src/EncryptedRow.php#L535) is not caught. It also does not extend `ErrorException` but rather `Exception`.

This causes an issue when fetching only specific properties of a model.