### PR TITLE
Add AAD to CustomBackend test

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,12 +275,12 @@ class CustomBackend implements BackendInterface {
         // Your logic here.return new SymmetricKey('123');
     }
 
-    public function doStreamDecrypt($inputFP, $outputFP, SymmetricKey $key, int $chunkSize = 8192): bool
+    public function doStreamDecrypt($inputFP, $outputFP, SymmetricKey $key, int $chunkSize = 8192, ?AAD $aad = null): bool
     {
         // Your logic here.
     }
 
-    public function doStreamEncrypt($inputFP, $outputFP, SymmetricKey $key, int $chunkSize = 8192, string $salt = Constants::DUMMY_SALT): bool
+    public function doStreamEncrypt($inputFP, $outputFP, SymmetricKey $key, int $chunkSize = 8192, string $salt = Constants::DUMMY_SALT, ?AAD $aad = null): bool
     {
         // Your logic here.
     }

--- a/tests/CustomBackendTest.php
+++ b/tests/CustomBackendTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\DB;
+use ParagonIE\CipherSweet\AAD;
 use ParagonIE\CipherSweet\Backend\Key\SymmetricKey;
 use ParagonIE\CipherSweet\CipherSweet;
 use ParagonIE\CipherSweet\Contract\BackendInterface;
@@ -76,7 +77,8 @@ class CustomBackend implements BackendInterface
         $inputFP,
         $outputFP,
         SymmetricKey $key,
-        int $chunkSize = 8192
+        int $chunkSize = 8192,
+        ?AAD $aad = null
     ): bool {
         return true;
     }
@@ -86,7 +88,8 @@ class CustomBackend implements BackendInterface
         $outputFP,
         SymmetricKey $key,
         int $chunkSize = 8192,
-        string $salt = Constants::DUMMY_SALT
+        string $salt = Constants::DUMMY_SALT,
+        ?AAD $aad = null
     ): bool {
         return true;
     }


### PR DESCRIPTION
Fixes the currently breaking tests referenced in https://github.com/spatie/laravel-ciphersweet/pull/69.

Ciphersweet added AAD support in v4.7.0: https://github.com/paragonie/ciphersweet/releases/tag/v4.7.0