### PR TITLE
Fixing model observers integration

### DIFF
--- a/src/Concerns/UsesCipherSweet.php
+++ b/src/Concerns/UsesCipherSweet.php
@@ -69,11 +69,12 @@ trait UsesCipherSweet
             ->where('indexable_id', $this->getKey())
             ->delete();
     }
-
     public function decryptRow(): void
     {
-        $this->setRawAttributes(static::$cipherSweetEncryptedRow->setPermitEmpty(config('ciphersweet.permit_empty', false))->decryptRow($this->getAttributes()), true);
+        $this->setRawAttributes(static::$cipherSweetEncryptedRow->setPermitEmpty(config('ciphersweet.permit_empty', false))
+            ->decryptRow($this->getAttributes()), false);
     }
+
 
     public function scopeWhereBlind(
         Builder $query,

--- a/tests/ObserverTest.php
+++ b/tests/ObserverTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Support\Facades\Log;
+use Spatie\LaravelCipherSweet\Tests\TestClasses\User;
+use Spatie\LaravelCipherSweet\Tests\TestClasses\UserObserver;
+
+
+it('whatever', function () {
+    $user = User::create([
+        'name' => 'John Doe',
+        'password' => bcrypt('password'),
+        'email' => 'john@example.com',
+    ]);
+
+    Log::spy();
+    User::observe(UserObserver::class);
+    $user->update(['email' => 'NewEmail@example.com']);
+
+    Log::shouldHaveReceived('info')
+        ->with("saving: dirty=2")
+        ->once();
+
+    Log::shouldHaveReceived('info')
+        ->with("saved: dirty=2")
+        ->once();
+});

--- a/tests/ObserverTest.php
+++ b/tests/ObserverTest.php
@@ -5,7 +5,7 @@ use Spatie\LaravelCipherSweet\Tests\TestClasses\User;
 use Spatie\LaravelCipherSweet\Tests\TestClasses\UserObserver;
 
 
-it('whatever', function () {
+it('persist dirty flag in observers', function () {
     $user = User::create([
         'name' => 'John Doe',
         'password' => bcrypt('password'),

--- a/tests/ObserverTest.php
+++ b/tests/ObserverTest.php
@@ -13,6 +13,7 @@ it('persist dirty flag in observers', function () {
     ]);
 
     Log::spy();
+
     User::observe(UserObserver::class);
     $user->update(['email' => 'NewEmail@example.com']);
 

--- a/tests/TestClasses/UserObserver.php
+++ b/tests/TestClasses/UserObserver.php
@@ -1,0 +1,19 @@
+<?php
+namespace Spatie\LaravelCipherSweet\Tests\TestClasses;
+
+class UserObserver
+{
+    public function saved(User $user)
+    {
+        $msg = "saved: dirty=".sizeof($user->getDirty());
+        \Log::info($msg);
+    }
+
+    public function saving(User $user)
+    {
+        $user->name .=".";
+
+        $msg = "saving: dirty=".sizeof($user->getDirty());
+        \Log::info($msg);
+    }
+}


### PR DESCRIPTION
When using model observers saved feature, the old dirty flags were reset to nothing. So you were not able to retrieve any old or updated values.

Sometimes this is needed to do some action after saving a changed model