### PR TITLE
Revert PR #74 and fix getChanges()

### DIFF
--- a/src/Observers/ModelObserver.php
+++ b/src/Observers/ModelObserver.php
@@ -23,12 +23,21 @@ class ModelObserver
 
     public function saving(CipherSweetEncrypted $model): void
     {
+        $model->saveDirtyAttributesForCipherSweet();
+
         $model->encryptRow();
+
+        // NOTE: If other listeners are called after this, all the encrypted attributes will appear in the dirty list
+        // since each field will contain their encrypted value.
+        // Having "Listener priority" might fix this (put the encrypter at the lowest priority
+        // so all other listeners are called first), but Laravel doesn't support that (yet).
     }
 
     public function saved(CipherSweetEncrypted $model): void
     {
         $model->decryptRow();
+
+        $model->excludeNonChangedEncryptedAttributesFromChanges();
 
         $model->updateBlindIndexes();
     }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use Spatie\LaravelCipherSweet\Tests\TestClasses\User;
+
+it('can have correct attributes|dirty|changes properties',function () {
+    expect(User::count(), 0);
+
+    $user = User::create([
+        'name' => 'John Doe',
+        'password' => bcrypt('password'),
+        'email' => 'john@example.com',
+    ]);
+
+    expect($user)
+        ->name->toBe('John Doe')
+        ->getAttribute('name')->toBe('John Doe')
+        ->created_at->not()->toBeNull()
+        ->updated_at->not()->toBeNull()
+        ->isDirty()->toBeFalse()
+        ->isClean()->toBeTrue()
+        ->getDirty()->toBeEmpty()
+        ->getOriginal('name')->toBe('John Doe')
+        ->wasChanged()->toBeFalse()
+        ->getChanges()->toBeEmpty();
+
+    expect(User::count(), 1);
+
+    $user = User::first();
+
+    expect($user)
+        ->name->toBe('John Doe')
+        ->getAttribute('name')->toBe('John Doe')
+        ->created_at->not()->toBeNull()
+        ->updated_at->not()->toBeNull()
+        ->isDirty()->toBeFalse()
+        ->isClean()->toBeTrue()
+        ->getDirty()->toBeEmpty()
+        ->getOriginal('name')->toBe('John Doe')
+        ->wasChanged()->toBeFalse()
+        ->getChanges()->toBeEmpty();
+
+    $user->name = 'New name';
+
+    expect($user)
+        ->name->toBe('New name')
+        ->getAttribute('name')->toBe('New name')
+        ->isDirty()->toBeTrue()
+        ->isClean()->toBeFalse()
+        ->getDirty()->toBe(['name' => 'New name'])
+        ->getOriginal('name')->toBe('John Doe')
+        ->wasChanged()->toBeFalse()
+        ->getChanges()->toBeEmpty();
+
+    $createdAt = $user->created_at;
+    $updatedAt = $user->updated_at;
+
+    $this->travel(1)->seconds();
+    $user->save();
+    $this->travelBack();
+
+    expect($user)
+        ->name->toBe('New name')
+        ->getAttribute('name')->toBe('New name')
+        ->created_at->toEqual($createdAt)
+        ->updated_at->toBeGreaterThan($updatedAt)
+        ->isDirty()->toBeFalse()
+        ->isClean()->toBeTrue()
+        ->getDirty()->toBeEmpty()
+        ->getOriginal('name')->toBe('New name')
+        ->wasChanged('name')->toBeTrue()
+        ->wasChanged('password')->toBeFalse()
+        ->wasChanged('email')->toBeFalse()
+        ->getChanges()->toBe([
+            'name' => 'New name',
+            'updated_at' => (string) $user->updated_at,
+        ]);
+});

--- a/tests/ObserverTest.php
+++ b/tests/ObserverTest.php
@@ -14,13 +14,40 @@ it('persist dirty flag in observers', function () {
     Log::spy();
 
     User::observe(UserObserver::class);
+
+    $this->travel(1)->seconds();    // to force updated_at to be updated
     $user->update(['email' => 'NewEmail@example.com']);
+    $this->travelBack();
 
     Log::shouldHaveReceived('info')
-        ->with("saving: dirty=2")
+        ->with("saving: dirty=2")  // name attribute + encrypted email attribute
         ->once();
 
     Log::shouldHaveReceived('info')
-        ->with("saved: dirty=2")
+        ->with("saved: changed=3")    // the name, updated_at & email attribute
+        ->once();
+});
+
+it('can exclude unmodified attributes from changes', function () {
+    $user = User::create([
+        'name' => 'John Doe',
+        'password' => bcrypt('password'),
+        'email' => 'john@example.com',
+    ]);
+
+    Log::spy();
+
+    User::observe(UserObserver::class);
+
+    $this->travel(1)->seconds();    // to force updated_at to be updated
+    $user->update(['name' => 'John Doe2']);
+    $this->travelBack();
+
+    Log::shouldHaveReceived('info')
+        ->with("saving: dirty=2")  // name attribute + encrypted email attribute (encrypted are always present)
+        ->once();
+
+    Log::shouldHaveReceived('info')
+        ->with("saved: changed=2")    // the name & updated_at attribute
         ->once();
 });

--- a/tests/TestClasses/UserObserver.php
+++ b/tests/TestClasses/UserObserver.php
@@ -6,7 +6,7 @@ class UserObserver
 {
     public function saved(User $user)
     {
-        $msg = "saved: dirty=".sizeof($user->getDirty());
+        $msg = "saved: changed=".sizeof($user->getChanges());
         \Log::info($msg);
     }
 


### PR DESCRIPTION
Revert PR #74 since the getDirty() Model method, in the saved event, should return an empty array (the model was saved; attributes are no longer dirty).

I also fixed Model getChanges()

@yormy 
getChanges() is what should be used to know which fields were updated.
the returned array contains the attribute name that was updated as the key and the new value as the value.
To get the previous value of those fields, we need to catch them in the saving event first. Then in the saved event, we can use them and compare them to the newly saved value.

Spatie ActivityLog does it this way.
@see https://github.com/spatie/laravel-activitylog/blob/2b3f96c1a5fe3b265197e09cbed813efc96fb6e8/src/Traits/LogsActivity.php#L43


Previously, getChanges contained all the encrypted fields even when none were updated.
(the reason is that the changes attributes was updated AFTER then encryption of the attributes had happened; all the encrypted field values were encrypted and they are different compared to the unencrypted value)

Now, they will only appear if they were updated. Also, their value will be the unencrypted one. Previously, the encrypted value was returned, which is of no use in an event listener.