### PR TITLE
Add `EncryptedUniqueRule` for Encrypted Unique Validation

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,13 +17,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.1]
-        laravel: ['9.*', '10.*', '11.*', '12.*']
+        laravel: ['10.*', '11.*', '12.*']
         stability: [prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
-          - laravel: 9.*
-            testbench: 7.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*

--- a/README.md
+++ b/README.md
@@ -229,6 +229,53 @@ php artisan ciphersweet:encrypt "App\User" <your-new-key>
 
 This will update all the encrypted fields and blind indexes of the model. Once this is done, you can update your environment or config file to use the new key.
 
+## Encrypted Unique Validation Rule
+
+You can now validate encrypted fields for uniqueness using the new `EncryptedUniqueRule`.
+
+When working with encrypted fields and blind indexes, Laravel’s default `Rule::unique()` validation doesn't work out of the box. This package includes a custom rule to check for uniqueness via blind indexes.
+
+### Usage
+
+You may use the rule directly:
+
+```php
+use Spatie\LaravelCipherSweet\Rules\EncryptedUniqueRule;
+
+$request->validate([
+    'email' => [new EncryptedUniqueRule(User::class, 'email_index')],
+]);
+```
+
+Or, for a more expressive approach, use the macro added to Laravel’s `Rule` class:
+
+```php
+use Illuminate\Validation\Rule;
+
+$request->validate([
+    'email' => [Rule::encryptedUnique(User::class, 'email_index')],
+]);
+```
+
+> The third parameter of the rule is the database column name. If not provided, it will default to the validation attribute name (i.e., `email` in the example above).
+
+### Ignoring a Record (e.g. on update)
+
+You can skip a specific record by using the `ignore()` method:
+
+```php
+Rule::encryptedUnique(User::class, 'email_index')->ignore($user->id)
+```
+
+Or pass the model instance:
+
+```php
+Rule::encryptedUnique(User::class, 'email_index')->ignoreModel($user)
+```
+
+> 💡 Ensure the target model implements `Spatie\LaravelCipherSweet\Contracts\CipherSweetEncrypted` and defines the appropriate blind index.
+
+
 ## Implementing a custom backend
 
 You can implement a custom backend by setting the `ciphersweet.backend` config value to `custom`.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ This will update all the encrypted fields and blind indexes of the model. Once t
 
 ## Encrypted Unique Validation Rule
 
-You can now validate encrypted fields for uniqueness using the new `EncryptedUniqueRule`.
+You can validate encrypted fields for uniqueness using `EncryptedUniqueRule`.
 
 When working with encrypted fields and blind indexes, Laravel’s default `Rule::unique()` validation doesn't work out of the box. This package includes a custom rule to check for uniqueness via blind indexes.
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^9.19|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
         "paragonie/ciphersweet": "^4.0.1",
         "spatie/laravel-package-tools": "^1.12.0"
     },

--- a/src/LaravelCipherSweetServiceProvider.php
+++ b/src/LaravelCipherSweetServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelCipherSweet;
 
+use Illuminate\Validation\Rule;
 use ParagonIE\CipherSweet\Backend\BoringCrypto;
 use ParagonIE\CipherSweet\Backend\FIPSCrypto;
 use ParagonIE\CipherSweet\Backend\ModernCrypto;
@@ -13,6 +14,7 @@ use ParagonIE\CipherSweet\KeyProvider\RandomProvider;
 use ParagonIE\CipherSweet\KeyProvider\StringProvider;
 use Spatie\LaravelCipherSweet\Commands\EncryptCommand;
 use Spatie\LaravelCipherSweet\Commands\GenerateKeyCommand;
+use Spatie\LaravelCipherSweet\Rules\EncryptedUniqueRule;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -33,6 +35,10 @@ class LaravelCipherSweetServiceProvider extends PackageServiceProvider
             $backend = $this->buildBackend();
 
             return new CipherSweet($this->buildKeyProvider($backend), $backend);
+        });
+
+        Rule::macro('encryptedUnique', function (string $model, string $indexName, string $column = null) {
+            return new EncryptedUniqueRule($model, $indexName, $column);
         });
     }
 

--- a/src/Rules/EncryptedUniqueRule.php
+++ b/src/Rules/EncryptedUniqueRule.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Spatie\LaravelCipherSweet\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Database\Eloquent\Model;
+use RuntimeException;
+use Spatie\LaravelCipherSweet\Contracts\CipherSweetEncrypted;
+
+class EncryptedUniqueRule implements ValidationRule
+{
+    /**
+     * The ID that should be ignored.
+     *
+     */
+    protected mixed $ignore = null;
+
+    /**
+     * The name of the ID column.
+     *
+     * @var string
+     */
+    protected $idColumn = 'id';
+
+    public function __construct(
+        protected string  $model,
+        protected string  $indexName,
+        protected ?string $column = null
+    ) {
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $this->column ??= $attribute;
+
+        $this->checkModelHasEncryptedColumn();
+
+        $count = $this->model::whereBlind(
+            $this->column,
+            $this->indexName,
+            $value
+        )
+            ->when($this->ignore, function ($query) {
+                $query->whereNot($this->idColumn, $this->ignore);
+            })
+            ->count();
+
+        if ($count) {
+            $fail(trans('validation.unique', [
+                'attribute' => $this->column,
+            ]));
+        }
+    }
+
+    /**
+     * Ignore the given ID during the unique check.
+     *
+     * @param mixed       $id
+     * @param string|null $idColumn
+     * @return $this
+     */
+    public function ignore(mixed $id, ?string $idColumn = null): static
+    {
+        if ($id instanceof Model) {
+            return $this->ignoreModel($id, $idColumn);
+        }
+
+        $this->ignore = $id;
+        $this->idColumn = $idColumn ?? 'id';
+
+        return $this;
+    }
+
+    /**
+     * Ignore the given model during the unique check.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param string|null                         $idColumn
+     * @return $this
+     */
+    public function ignoreModel(Model $model, ?string $idColumn = null): static
+    {
+        $this->idColumn = $idColumn ?? $model->getKeyName();
+        $this->ignore = $model->{$this->idColumn};
+
+        return $this;
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    private function checkModelHasEncryptedColumn(): void
+    {
+        if (! (new $this->model()) instanceof CipherSweetEncrypted) {
+            throw new RuntimeException("The model {$this->model} must implement " . CipherSweetEncrypted::class);
+        }
+    }
+}

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Support\Facades\Validator;
+use Spatie\LaravelCipherSweet\Contracts\CipherSweetEncrypted;
+use Spatie\LaravelCipherSweet\Rules\EncryptedUniqueRule;
+use Spatie\LaravelCipherSweet\Tests\TestClasses\NormalUser;
+use Spatie\LaravelCipherSweet\Tests\TestClasses\User;
+
+// Setup a fake model that implements CipherSweetEncrypted
+beforeEach(function () {
+    User::truncate();
+});
+
+it('passes when value is unique', function () {
+    $rule = new EncryptedUniqueRule(User::class, 'email_index');
+
+    $validator = Validator::make([
+        'email' => 'unique@example.com',
+    ], [
+        'email' => [$rule],
+    ]);
+
+    expect($validator->passes())->toBeTrue();
+});
+
+it('fails when value already exists', function () {
+    User::create([
+        'name' => 'John Doe',
+        'password' => bcrypt('password'),
+        'email' => 'duplicate@example.com',
+    ]);
+
+    $rule = new EncryptedUniqueRule(User::class, 'email_index');
+
+    $validator = Validator::make([
+        'email' => 'duplicate@example.com',
+    ], [
+        'email' => [$rule],
+    ]);
+
+    expect($validator->fails())->toBeTrue();
+    expect($validator->errors()->first('email'))->toContain('The email has already been taken');
+});
+
+it('ignores the given id when using ignore method', function () {
+    $user = User::create([
+        'name' => 'John Doe',
+        'password' => bcrypt('password'),
+        'email' => 'someone@example.com',
+    ]);
+
+    $rule = (new EncryptedUniqueRule(User::class, 'email_index'))->ignore($user->id);
+
+    $validator = Validator::make([
+        'email' => 'someone@example.com',
+    ], [
+        'email' => [$rule],
+    ]);
+
+    expect($validator->passes())->toBeTrue();
+});
+
+it('throws exception if model does not implement CipherSweetEncrypted', function () {
+    $rule = new EncryptedUniqueRule(NormalUser::class, 'email_index');
+
+    Validator::make([
+        'email' => 'example@example.com',
+    ], [
+        'email' => [$rule],
+    ])->passes(); // This should throw
+})->throws(RuntimeException::class, "The model " . NormalUser::class . " must implement " . CipherSweetEncrypted::class);

--- a/tests/TestClasses/NormalUser.php
+++ b/tests/TestClasses/NormalUser.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\LaravelCipherSweet\Tests\TestClasses;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NormalUser extends Model
+{
+    protected $guarded = [];
+}


### PR DESCRIPTION
Hi,

This PR introduces a new `EncryptedUniqueRule` class, enabling developers to validate encrypted fields against uniqueness constraints within Laravel's validation system.

### Why this is useful

In applications using **Ciphersweet** for encrypted data, standard `unique` validation rules do not work as expected, since the database stores ciphertext. This rule bridges that gap by:

- Allowing **encrypted fields** to be validated for uniqueness at the application level.
- Integrating seamlessly with Laravel’s native validation system.
- Enhancing developer experience without compromising encryption practices.

### Example usage

```php
$request->validate([
    'email' => [new EncryptedUniqueRule(model: User::class, indexName: 'email_index' , column: 'email')],
    // or
    'email' => Rule::encryptedUnique(User::class, 'email_index', 'email')->ignore($this->route()->id),
]);
```
