### PR TITLE
[fix] Generate key command overrides current key without model reencryption.

### DIFF
--- a/src/Commands/GenerateKeyCommand.php
+++ b/src/Commands/GenerateKeyCommand.php
@@ -4,11 +4,14 @@ namespace Spatie\LaravelCipherSweet\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Database\Eloquent\Model;
 use ParagonIE\ConstantTime\{
     Base64UrlSafe,
     Hex
 };
+use Spatie\LaravelCipherSweet\Contracts\CiphersweetEncrypted;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Helper\ProgressBar;
 
 #[AsCommand(name: 'ciphersweet:generate-key')]
 class GenerateKeyCommand extends Command
@@ -20,7 +23,7 @@ class GenerateKeyCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'ciphersweet:generate-key
+    protected $signature = 'ciphersweet:generate-key-test
         {--show : Display the CipherSweet key instead of modifying files}
         {--base64 : Generate key in base64 safe format}
         {--force : Force the operation to run when in production}';
@@ -37,8 +40,7 @@ class GenerateKeyCommand extends Command
      *
      * @return void
      */
-    public function handle()
-    {
+    public function handle() {
         $key = $this->generateRandomKey();
 
         if ($this->option('show')) {
@@ -47,7 +49,13 @@ class GenerateKeyCommand extends Command
             return;
         }
 
-        if (! $this->setKeyInEnvironmentFile($key)) {
+        if (!$this->replaceCurrentKey()) {
+            return;
+        }
+
+        $this->reencryptExistingData($key);
+
+        if (!$this->setKeyInEnvironmentFile($key)) {
             return;
         }
 
@@ -61,13 +69,12 @@ class GenerateKeyCommand extends Command
      *
      * @return string
      */
-    protected function generateRandomKey(): string
-    {
+    protected function generateRandomKey(): string {
         $randomBytes = $this->generateRandomBytes();
 
         return $this->option('base64')
-           ? Base64UrlSafe::encode($randomBytes)
-           : Hex::encode($randomBytes);
+            ? Base64UrlSafe::encode($randomBytes)
+            : Hex::encode($randomBytes);
     }
 
     /**
@@ -75,26 +82,32 @@ class GenerateKeyCommand extends Command
      *
      * @return string
      */
-    protected function generateRandomBytes(): string
-    {
+    protected function generateRandomBytes(): string {
         return random_bytes(32);
+    }
+
+    /**
+     * Confirm if the current key should be replaced.
+     *
+     * @return bool
+     */
+    protected function replaceCurrentKey(): bool {
+        $currentKey = $this->laravel['config']['ciphersweet.providers.string.key'];
+
+        if (strlen($currentKey) !== 0 && (!$this->confirmToProceed())) {
+            return false;
+        }
+        return true;
     }
 
     /**
      * Set the CipherSweet key in the environment file.
      *
-     * @param  string  $key
+     * @param string $key
      * @return bool
      */
-    protected function setKeyInEnvironmentFile($key): bool
-    {
-        $currentKey = $this->laravel['config']['ciphersweet.providers.string.key'];
-
-        if (strlen($currentKey) !== 0 && (! $this->confirmToProceed())) {
-            return false;
-        }
-
-        if (! $this->writeNewEnvironmentFileWith($key)) {
+    protected function setKeyInEnvironmentFile($key): bool {
+        if (!$this->writeNewEnvironmentFileWith($key)) {
             return false;
         }
 
@@ -104,16 +117,21 @@ class GenerateKeyCommand extends Command
     /**
      * Write a new environment file with the given CipherSweet key.
      *
-     * @param  string  $key
+     * @param string $key
      * @return bool
      */
-    protected function writeNewEnvironmentFileWith($key)
-    {
-        $replaced = preg_replace(
-            $this->keyReplacementPattern(),
-            'CIPHERSWEET_KEY=' . $key,
-            $input = file_get_contents($this->laravel->environmentFilePath())
-        );
+    protected function writeNewEnvironmentFileWith($key): bool {
+        $input = file_get_contents($this->laravel->environmentFilePath());
+
+        if (!$this->hasKeyPattern($input)) {
+            $replaced = $input . PHP_EOL . 'CIPHERSWEET_KEY=' . $key . PHP_EOL;
+        } else {
+            $replaced = preg_replace(
+                $this->keyReplacementPattern(),
+                'CIPHERSWEET_KEY=' . $key,
+                $input
+            );
+        }
 
         if ($replaced === $input || $replaced === null) {
             $this->error('Unable to set CipherSweet key. No CIPHERSWEET_KEY variable was found in the .env file.');
@@ -127,14 +145,84 @@ class GenerateKeyCommand extends Command
     }
 
     /**
+     * Check if environment file has a CIPHERSWEET_KEY variable.
+     *
+     * @param string $file_content
+     * @return bool
+     */
+    protected function hasKeyPattern($file_content): bool {
+        if (preg_match('/^CIPHERSWEET_KEY=/m', $file_content)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Get a regex pattern that will match env CIPHERSWEET_KEY with any random key.
      *
      * @return string
      */
-    protected function keyReplacementPattern()
-    {
+    protected function keyReplacementPattern(): string {
         $escaped = preg_quote('=' . $this->laravel['config']['ciphersweet.providers.string.key'], '/');
 
         return "/^CIPHERSWEET_KEY{$escaped}/m";
+    }
+
+    /**
+     * Re-encrypt existing data with the new key.
+     *
+     * @param $key
+     * @return void
+     */
+    protected function reencryptExistingData($key): void {
+        $modelClasses = $this->getModels();
+
+        ProgressBar::setFormatDefinition('custom', ' %current%/%max% [%bar%] %message%');
+
+        $progressBar = $this->output->createProgressBar(count($modelClasses));
+        $progressBar->setFormat('custom');
+
+        $progressBar->start();
+
+        foreach ($modelClasses as $modelClass) {
+            $progressBar->setMessage("Re-encrypting " . $modelClass);
+            $progressBar->advance();
+
+            try {
+                $this->callSilent('ciphersweet:encrypt', [
+                    'model' => $modelClass,
+                    'newKey' => $key,
+                ]);
+            } catch (\Throwable $th) {
+                $this->components->error("Error re-encrypting model {$modelClass}: " . $th->getMessage());
+            }
+        }
+
+        $progressBar->finish();
+    }
+
+    /**
+     * Get all model classes in the app/Models directory.
+     *
+     * @return array
+     */
+    protected function getModels(): array {
+        $modelClasses = [];
+        $modelPath = app_path('Models');
+        $files = scandir($modelPath);
+        foreach ($files as $file) {
+            if (!preg_match('/^.*\.php$/', $file)) continue;
+
+            $modelClass = 'App\\Models\\' . pathinfo($file, PATHINFO_FILENAME);
+            if (!class_exists($modelClass)) continue;
+
+            $model = (new $modelClass());
+            if (!$model instanceof Model) continue;
+            if (!$model instanceof CiphersweetEncrypted) continue;
+
+            $modelClasses[] = 'App\\Models\\' . pathinfo($file, PATHINFO_FILENAME);
+        }
+
+        return $modelClasses;
     }
 }

--- a/src/Commands/GenerateKeyCommand.php
+++ b/src/Commands/GenerateKeyCommand.php
@@ -23,7 +23,7 @@ class GenerateKeyCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'ciphersweet:generate-key-test
+    protected $signature = 'ciphersweet:generate-key
         {--show : Display the CipherSweet key instead of modifying files}
         {--base64 : Generate key in base64 safe format}
         {--force : Force the operation to run when in production}';


### PR DESCRIPTION
Added:
Reencrypting of all models in App\Models directory on key change.
Automatic .env variable creation if not exist (CIPHERSWEET_KEY).