### PR TITLE
fix: ensure validation attribute is translated in EncryptedUniqueRule

### DIFF
--- a/src/Rules/EncryptedUniqueRule.php
+++ b/src/Rules/EncryptedUniqueRule.php
@@ -47,9 +47,7 @@ class EncryptedUniqueRule implements ValidationRule
             ->count();
 
         if ($count) {
-            $fail(trans('validation.unique', [
-                'attribute' => $this->column,
-            ]));
+            $fail('validation.unique')->translate();
         }
     }
 

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -76,3 +76,24 @@ it('creates an encryptedUnique rule via macro', function () {
 
     expect($rule)->toBeInstanceOf(EncryptedUniqueRule::class);
 });
+
+it('correctly uses the translated attribute name', function () {
+    User::create([
+        'name' => 'John Doe',
+        'password' => bcrypt('password'),
+        'email' => 'duplicate@example.com',
+    ]);
+
+    $rule = new EncryptedUniqueRule(User::class, 'email_index');
+
+    $validator = Validator::make([
+        'email' => 'duplicate@example.com',
+    ], [
+        'email' => [$rule],
+    ], [], [
+        'email' => 'custom address',
+    ]);
+
+    expect($validator->fails())->toBeTrue();
+    expect($validator->errors()->first('email'))->toContain('The custom address has already been taken');
+});


### PR DESCRIPTION
## Description

Currently, `EncryptedUniqueRule` manually replaces the `:attribute` placeholder in the validation message with the raw column name. This prevents Laravel's standard attribute translation mechanism from working correctly.
This PR changes the rule to use the standard `$fail()->translate()` pattern, allowing the validator to correctly look up and substitute the translated attribute name from `validation.attributes`.

## Changes
- Updated `EncryptedUniqueRule` to use `$fail()->translate()`.
- Added a test case in `RuleTest.php` to verify that custom attribute names are correctly honored in the error message.