### PR TITLE
Add database connection support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ testbench.yaml
 vendor
 node_modules
 .php-cs-fixer.cache
+.phpunit.cache

--- a/config/ciphersweet.php
+++ b/config/ciphersweet.php
@@ -50,5 +50,11 @@ return [
      * the field to have a value and alerts the user if it is empty or undefined.
      * Supported: "true", "false"
      */
-    'permit_empty' => env('CIPHERSWEET_PERMIT_EMPTY', FALSE)
+    'permit_empty' => env('CIPHERSWEET_PERMIT_EMPTY', FALSE),
+
+    /*
+     * The database connection to use for the blind_indexes table.
+     * When null, the default database connection will be used.
+     */
+    'connection' => env('CIPHERSWEET_CONNECTION', null),
 ];

--- a/database/migrations/create_blind_indexes_table.php
+++ b/database/migrations/create_blind_indexes_table.php
@@ -6,9 +6,14 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    public function __construct()
+    {
+        $this->connection = config('ciphersweet.connection');
+    }
+
     public function up()
     {
-        Schema::create('blind_indexes', function (Blueprint $table) {
+        Schema::connection($this->connection)->create('blind_indexes', function (Blueprint $table) {
             $table->morphs('indexable');
             $table->string('name');
             $table->string('value');

--- a/src/Commands/EncryptCommand.php
+++ b/src/Commands/EncryptCommand.php
@@ -64,13 +64,15 @@ class EncryptCommand extends Command
 
         $newClass = (new $modelClass());
 
-        $this->getOutput()->progressStart(DB::table($newClass->getTable())->count());
+        $connection = DB::connection($newClass->getConnectionName());
+
+        $this->getOutput()->progressStart($connection->table($newClass->getTable())->count());
         $sortDirection = $this->argument('sortDirection');
 
-        DB::table($newClass->getTable())
+        $connection->table($newClass->getTable())
             ->orderBy((new $modelClass())
                 ->getKeyName(), $sortDirection)
-            ->each(function (object $model) use ($modelClass, $newClass, &$updatedRows) {
+            ->each(function (object $model) use ($modelClass, $newClass, $connection, &$updatedRows) {
                 $table_name = $this->argument('tablename') ?: $newClass->getTable();
                 $model = (array)$model;
 
@@ -91,12 +93,12 @@ class EncryptCommand extends Command
                         [$ciphertext, $indices] = $newRow->prepareRowForStorage($model);
                     }
 
-                    DB::table($newClass->getTable())
+                    $connection->table($newClass->getTable())
                         ->where($newClass->getKeyName(), $model[$newClass->getKeyName()])
                         ->update(Arr::only($ciphertext, $newRow->listEncryptedFields()));
 
                     foreach ($indices as $name => $value) {
-                        DB::table('blind_indexes')->updateOrInsert([
+                        $connection->table('blind_indexes')->updateOrInsert([
                             'indexable_type' => $newClass->getMorphClass(),
                             'indexable_id' => $model[$newClass->getKeyName()],
                             'name' => $name,

--- a/src/Concerns/UsesCipherSweet.php
+++ b/src/Concerns/UsesCipherSweet.php
@@ -74,7 +74,7 @@ trait UsesCipherSweet
     public function updateBlindIndexes(): void
     {
         foreach (static::getCipherSweetEncryptedRow()->getAllBlindIndexes($this->getAttributes()) as $name => $blindIndex) {
-            DB::table('blind_indexes')->upsert([
+            DB::connection($this->getConnectionName())->table('blind_indexes')->upsert([
                 'value' => $blindIndex,
                 'indexable_type' => $this->getMorphClass(),
                 'indexable_id' => $this->getKey(),
@@ -89,7 +89,7 @@ trait UsesCipherSweet
 
     public function deleteBlindIndexes(): void
     {
-        DB::table('blind_indexes')
+        DB::connection($this->getConnectionName())->table('blind_indexes')
             ->where('indexable_type', $this->getMorphClass())
             ->where('indexable_id', $this->getKey())
             ->delete();
@@ -157,10 +157,12 @@ trait UsesCipherSweet
         string $indexName,
         string|array $value
     ): Builder {
+        $prefix = $this->getConnection()->getTablePrefix();
+
         return $query->select(DB::raw(1))
             ->from('blind_indexes')
             ->where('indexable_type', $this->getMorphClass())
-            ->where('indexable_id', DB::raw(DB::getTablePrefix().$this->getTable() . '.' . $this->getKeyName()))
+            ->where('indexable_id', DB::raw($prefix.$this->getTable() . '.' . $this->getKeyName()))
             ->where('name', $indexName)
             ->where('value', static::getCipherSweetEncryptedRow()->getBlindIndex($indexName, [$column => $value]));
     }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Spatie\LaravelCipherSweet\Tests\TestClasses\UserOnSecondaryConnection;
+
+beforeEach(function () {
+    config()->set('database.connections.secondary', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+    ]);
+
+    Schema::connection('secondary')->create('users', function ($table) {
+        $table->increments('id');
+        $table->string('name');
+        $table->string('email');
+        $table->string('password');
+        $table->timestamps();
+    });
+
+    Schema::connection('secondary')->create('blind_indexes', function ($table) {
+        $table->morphs('indexable');
+        $table->string('name');
+        $table->string('value');
+        $table->index(['name', 'value']);
+        $table->unique(['indexable_type', 'indexable_id', 'name']);
+    });
+
+    UserOnSecondaryConnection::$cipherSweetEncryptedRow = null;
+
+    $this->user = UserOnSecondaryConnection::create([
+        'name' => 'John Doe',
+        'password' => bcrypt('password'),
+        'email' => 'john@example.com',
+    ]);
+});
+
+it('stores blind indexes on the model connection, not the default', function () {
+    expect(DB::connection('secondary')->table('blind_indexes')->count())->toBe(1);
+    expect(DB::table('blind_indexes')->count())->toBe(0);
+});
+
+it('encrypts and decrypts on the secondary connection', function () {
+    expect(DB::connection('secondary')->table('users')->first()->email)->toStartWith('nacl:')
+        ->and($this->user->email)->toEqual('john@example.com');
+});
+
+it('resolves whereBlind queries against the secondary connection', function () {
+    UserOnSecondaryConnection::create([
+        'name' => 'Jane Doe',
+        'password' => bcrypt('password'),
+        'email' => 'jane@example.com',
+    ]);
+
+    expect(UserOnSecondaryConnection::whereBlind('email', 'email_index', 'john@example.com')->count())->toBe(1);
+    expect(UserOnSecondaryConnection::whereBlind('email', 'email_index', 'john@example.com')->first()->is($this->user))->toBeTrue();
+
+    expect(
+        UserOnSecondaryConnection::whereBlind('email', 'email_index', 'john@example.com')
+            ->orWhereBlind('email', 'email_index', 'jane@example.com')
+            ->count()
+    )->toBe(2);
+});
+
+it('deletes blind indexes from the secondary connection', function () {
+    expect(DB::connection('secondary')->table('blind_indexes')->count())->toBe(1);
+
+    $this->user->delete();
+
+    expect(DB::connection('secondary')->table('blind_indexes')->count())->toBe(0);
+    expect(DB::table('blind_indexes')->count())->toBe(0);
+});
+
+it('runs ciphersweet:encrypt against the secondary connection', function () {
+    $this->artisan('ciphersweet:encrypt', [
+        'model' => UserOnSecondaryConnection::class,
+        'newKey' => \ParagonIE\ConstantTime\Hex::encode(random_bytes(32)),
+    ])->assertSuccessful()->expectsOutput('Updated 1 rows.');
+
+    expect(DB::connection('secondary')->table('blind_indexes')->count())->toBe(1);
+    expect(DB::table('blind_indexes')->count())->toBe(0);
+});

--- a/tests/TestClasses/UserOnSecondaryConnection.php
+++ b/tests/TestClasses/UserOnSecondaryConnection.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\LaravelCipherSweet\Tests\TestClasses;
+
+use Illuminate\Database\Eloquent\Model;
+use ParagonIE\CipherSweet\BlindIndex;
+use ParagonIE\CipherSweet\EncryptedRow;
+use Spatie\LaravelCipherSweet\Concerns\UsesCipherSweet;
+use Spatie\LaravelCipherSweet\Contracts\CipherSweetEncrypted;
+
+class UserOnSecondaryConnection extends Model implements CipherSweetEncrypted
+{
+    use UsesCipherSweet;
+
+    protected $connection = 'secondary';
+
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    public static function configureCipherSweet(EncryptedRow $encryptedRow): void
+    {
+        $encryptedRow
+            ->addField('email')
+            ->addBlindIndex('email', new BlindIndex('email_index'));
+    }
+}


### PR DESCRIPTION
# Summary

Why connection name support matters

Laravel applications often use multiple database connections — a common pattern is separating sensitive user data onto a dedicated database while keeping non-sensitive data on the default one.

Before this change, any model using protected $connection = 'secondary' would store its encrypted data on the secondary connection, but all blind_indexes reads and writes would silently go to the default connection. This caused:

- Silent data loss — blind indexes written to the wrong database are never found during lookups, so whereBlind/orWhereBlind always returns empty results.
- Broken uniqueness validation — EncryptedUniqueRule queries the wrong connection, so duplicate encrypted values are never detected.
- Stale index rows — deletes and re-encryptions update the wrong database, leaving orphaned rows behind.
- Broken ciphersweet:encrypt — the command read rows from the model's connection but wrote blind indexes to the default, producing an inconsistent state.

With this change, every operation follows the model's own connection, so the blind indexes always live alongside the data they index. The new ciphersweet.connection config key also lets teams that share one blind_indexes table across models (all on the same non-default connection) configure that once, without touching each model.

- All blind index operations (updateBlindIndexes, deleteBlindIndexes, whereBlind/orWhereBlind) now respect the model's configured database connection instead of always using the
  default connection.
- The ciphersweet:encrypt Artisan command now routes both model table queries and blind_indexes queries through the model's connection.
- The create_blind_indexes_table migration picks up a connection value from config, so the blind_indexes table can be created on a non-default connection.
- A new connection key (CIPHERSWEET_CONNECTION env var, default null) is added to config/ciphersweet.php.
