### PR TITLE
Respect the model's database connection for blind indexes

### DIFF
--- a/src/Commands/EncryptCommand.php
+++ b/src/Commands/EncryptCommand.php
@@ -64,13 +64,15 @@ class EncryptCommand extends Command
 
         $newClass = (new $modelClass());
 
-        $this->getOutput()->progressStart(DB::table($newClass->getTable())->count());
+        $connection = DB::connection($newClass->getConnectionName());
+
+        $this->getOutput()->progressStart($connection->table($newClass->getTable())->count());
         $sortDirection = $this->argument('sortDirection');
 
-        DB::table($newClass->getTable())
+        $connection->table($newClass->getTable())
             ->orderBy((new $modelClass())
                 ->getKeyName(), $sortDirection)
-            ->each(function (object $model) use ($modelClass, $newClass, &$updatedRows) {
+            ->each(function (object $model) use ($modelClass, $newClass, $connection, &$updatedRows) {
                 $table_name = $this->argument('tablename') ?: $newClass->getTable();
                 $model = (array)$model;
 
@@ -91,12 +93,12 @@ class EncryptCommand extends Command
                         [$ciphertext, $indices] = $newRow->prepareRowForStorage($model);
                     }
 
-                    DB::table($newClass->getTable())
+                    $connection->table($newClass->getTable())
                         ->where($newClass->getKeyName(), $model[$newClass->getKeyName()])
                         ->update(Arr::only($ciphertext, $newRow->listEncryptedFields()));
 
                     foreach ($indices as $name => $value) {
-                        DB::table('blind_indexes')->updateOrInsert([
+                        $connection->table('blind_indexes')->updateOrInsert([
                             'indexable_type' => $newClass->getMorphClass(),
                             'indexable_id' => $model[$newClass->getKeyName()],
                             'name' => $name,

--- a/src/Concerns/UsesCipherSweet.php
+++ b/src/Concerns/UsesCipherSweet.php
@@ -74,7 +74,7 @@ trait UsesCipherSweet
     public function updateBlindIndexes(): void
     {
         foreach (static::getCipherSweetEncryptedRow()->getAllBlindIndexes($this->getAttributes()) as $name => $blindIndex) {
-            DB::table('blind_indexes')->upsert([
+            DB::connection($this->getConnectionName())->table('blind_indexes')->upsert([
                 'value' => $blindIndex,
                 'indexable_type' => $this->getMorphClass(),
                 'indexable_id' => $this->getKey(),
@@ -89,7 +89,7 @@ trait UsesCipherSweet
 
     public function deleteBlindIndexes(): void
     {
-        DB::table('blind_indexes')
+        DB::connection($this->getConnectionName())->table('blind_indexes')
             ->where('indexable_type', $this->getMorphClass())
             ->where('indexable_id', $this->getKey())
             ->delete();
@@ -157,10 +157,12 @@ trait UsesCipherSweet
         string $indexName,
         string|array $value
     ): Builder {
+        $prefix = $this->getConnection()->getTablePrefix();
+
         return $query->select(DB::raw(1))
             ->from('blind_indexes')
             ->where('indexable_type', $this->getMorphClass())
-            ->where('indexable_id', DB::raw(DB::getTablePrefix().$this->getTable() . '.' . $this->getKeyName()))
+            ->where('indexable_id', DB::raw($prefix.$this->getTable() . '.' . $this->getKeyName()))
             ->where('name', $indexName)
             ->where('value', static::getCipherSweetEncryptedRow()->getBlindIndex($indexName, [$column => $value]));
     }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Spatie\LaravelCipherSweet\Tests\TestClasses\UserOnSecondaryConnection;
+
+beforeEach(function () {
+    config()->set('database.connections.secondary', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+    ]);
+
+    Schema::connection('secondary')->create('users', function ($table) {
+        $table->increments('id');
+        $table->string('name');
+        $table->string('email');
+        $table->string('password');
+        $table->timestamps();
+    });
+
+    // The blind_indexes table lives on the same connection as the model that
+    // uses it. In a real app you publish the migration and point it at this
+    // connection; here we create it directly on the secondary connection.
+    Schema::connection('secondary')->create('blind_indexes', function ($table) {
+        $table->morphs('indexable');
+        $table->string('name');
+        $table->string('value');
+        $table->index(['name', 'value']);
+        $table->unique(['indexable_type', 'indexable_id', 'name']);
+    });
+
+    UserOnSecondaryConnection::$cipherSweetEncryptedRow = null;
+
+    $this->user = UserOnSecondaryConnection::create([
+        'name' => 'John Doe',
+        'password' => bcrypt('password'),
+        'email' => 'john@example.com',
+    ]);
+});
+
+it('stores blind indexes on the model connection, not the default', function () {
+    expect(DB::connection('secondary')->table('blind_indexes')->count())->toBe(1);
+    expect(DB::table('blind_indexes')->count())->toBe(0);
+});
+
+it('encrypts and decrypts on the secondary connection', function () {
+    expect(DB::connection('secondary')->table('users')->first()->email)->toStartWith('nacl:')
+        ->and($this->user->email)->toEqual('john@example.com');
+});
+
+it('resolves whereBlind queries against the secondary connection', function () {
+    UserOnSecondaryConnection::create([
+        'name' => 'Jane Doe',
+        'password' => bcrypt('password'),
+        'email' => 'jane@example.com',
+    ]);
+
+    expect(UserOnSecondaryConnection::whereBlind('email', 'email_index', 'john@example.com')->count())->toBe(1);
+    expect(UserOnSecondaryConnection::whereBlind('email', 'email_index', 'john@example.com')->first()->is($this->user))->toBeTrue();
+
+    expect(
+        UserOnSecondaryConnection::whereBlind('email', 'email_index', 'john@example.com')
+            ->orWhereBlind('email', 'email_index', 'jane@example.com')
+            ->count()
+    )->toBe(2);
+});
+
+it('deletes blind indexes from the secondary connection', function () {
+    expect(DB::connection('secondary')->table('blind_indexes')->count())->toBe(1);
+
+    $this->user->delete();
+
+    expect(DB::connection('secondary')->table('blind_indexes')->count())->toBe(0);
+    expect(DB::table('blind_indexes')->count())->toBe(0);
+});
+
+it('runs ciphersweet:encrypt against the secondary connection', function () {
+    $this->artisan('ciphersweet:encrypt', [
+        'model' => UserOnSecondaryConnection::class,
+        'newKey' => \ParagonIE\ConstantTime\Hex::encode(random_bytes(32)),
+    ])->assertSuccessful()->expectsOutput('Updated 1 rows.');
+
+    expect(DB::connection('secondary')->table('blind_indexes')->count())->toBe(1);
+    expect(DB::table('blind_indexes')->count())->toBe(0);
+});

--- a/tests/TestClasses/UserOnSecondaryConnection.php
+++ b/tests/TestClasses/UserOnSecondaryConnection.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\LaravelCipherSweet\Tests\TestClasses;
+
+use Illuminate\Database\Eloquent\Model;
+use ParagonIE\CipherSweet\BlindIndex;
+use ParagonIE\CipherSweet\EncryptedRow;
+use Spatie\LaravelCipherSweet\Concerns\UsesCipherSweet;
+use Spatie\LaravelCipherSweet\Contracts\CipherSweetEncrypted;
+
+class UserOnSecondaryConnection extends Model implements CipherSweetEncrypted
+{
+    use UsesCipherSweet;
+
+    protected $connection = 'secondary';
+
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    public static function configureCipherSweet(EncryptedRow $encryptedRow): void
+    {
+        $encryptedRow
+            ->addField('email')
+            ->addBlindIndex('email', new BlindIndex('email_index'));
+    }
+}


### PR DESCRIPTION
Builds on @batnieluyo's work in #100. Closes #100.

When a model sets `protected $connection = secondary`, its encrypted columns were stored on that connection but `blind_indexes` reads/writes silently hit the default connection. That broke `whereBlind`/`orWhereBlind` (empty results), `Rule::encryptedUnique`, deletes (orphaned rows), and `ciphersweet:encrypt`.

Now every blind index operation derives its connection from the model via `getConnectionName()`, including the `ciphersweet:encrypt` command and the table-prefix lookup in `buildBlindQuery`. For default-connection models `getConnectionName()` is `null`, so behavior is unchanged and it's fully backward compatible.

No config key is needed: the `blind_indexes` migration is published into the app, so a non-default connection is set by editing the published migration (`Schema::connection(...)`) to match the model.

Adds `tests/ConnectionTest.php` covering store, query, delete, encrypt/decrypt, and `ciphersweet:encrypt` against a secondary connection.